### PR TITLE
Escaped characters should be treated as valid

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -2,6 +2,10 @@
 
 var Parser = require("fastparse");
 
+function unescape(str) {
+	return str.replace(/\\(.)/g, "$1");
+}
+
 function commentMatch(match, content) {
 	this.selector.nodes.push({
 		type: "comment",
@@ -13,7 +17,7 @@ function typeMatch(type) {
 	return function(match, name) {
 		this.selector.nodes.push({
 			type: type,
-			name: name
+			name: unescape(name)
 		});
 	};
 }
@@ -21,7 +25,7 @@ function typeMatch(type) {
 function pseudoClassStartMatch(match, name) {
 	var newToken = {
 		type: "pseudo-class",
-		name: name,
+		name: unescape(name),
 		content: ""
 	};
 	this.selector.nodes.push(newToken);
@@ -37,7 +41,7 @@ function nestedPseudoClassStartMatch(match, name, after) {
 	};
 	var newToken = {
 		type: "nested-pseudo-class",
-		name: name,
+		name: unescape(name),
 		nodes: [newSelector]
 	};
 	if(after) {
@@ -88,10 +92,10 @@ function spacingMatch(match) {
 function elementMatch(match, namespace, name) {
 	var newToken = {
 		type: "element",
-		name: name
+		name: unescape(name)
 	};
 	if(namespace) {
-		newToken.namespace = namespace.substr(0, namespace.length - 1);
+		newToken.namespace = unescape(namespace.substr(0, namespace.length - 1));
 	}
 	this.selector.nodes.push(newToken);
 }
@@ -101,7 +105,7 @@ function universalMatch(match, namespace) {
 		type: "universal"
 	};
 	if(namespace) {
-		newToken.namespace = namespace.substr(0, namespace.length - 1);
+		newToken.namespace = unescape(namespace.substr(0, namespace.length - 1));
 	}
 	this.selector.nodes.push(newToken);
 }
@@ -162,16 +166,16 @@ function bracketEnd(match) {
 var parser = new Parser({
 	selector: {
 		"/\\*([\\s\\S]*?)\\*/": commentMatch,
-		"\\.([A-Za-z_\\-0-9]+)": typeMatch("class"),
-		"#([A-Za-z_\\-0-9]+)": typeMatch("id"),
+		"\\.((?:\\\\.|[A-Za-z_\\-])(?:\\\\.|[A-Za-z_\\-0-9])*)": typeMatch("class"),
+		"#((?:\\\\.|[A-Za-z_\\-])(?:\\\\.|[A-Za-z_\\-0-9])*)": typeMatch("id"),
 		":(not|has|local|global)\\((\\s*)": nestedPseudoClassStartMatch,
-		":([A-Za-z_\\-0-9]+)\\(": pseudoClassStartMatch,
-		":([A-Za-z_\\-0-9]+)": typeMatch("pseudo-class"),
-		"::([A-Za-z_\\-0-9]+)": typeMatch("pseudo-element"),
-		"(\\*\\|)([A-Za-z_\\-0-9]+)": elementMatch,
+		":((?:\\\\.|[A-Za-z_\\-0-9])+)\\(": pseudoClassStartMatch,
+		":((?:\\\\.|[A-Za-z_\\-0-9])+)": typeMatch("pseudo-class"),
+		"::((?:\\\\.|[A-Za-z_\\-0-9])+)": typeMatch("pseudo-element"),
+		"(\\*\\|)((?:\\\\.|[A-Za-z_\\-0-9])+)": elementMatch,
 		"(\\*\\|)\\*": universalMatch,
-		"([A-Za-z_\\-0-9]*\\|)?\\*": universalMatch,
-		"([A-Za-z_\\-0-9]*\\|)?([A-Za-z_\\-0-9]+)": elementMatch,
+		"((?:\\\\.|[A-Za-z_\\-0-9])*\\|)?\\*": universalMatch,
+		"((?:\\\\.|[A-Za-z_\\-0-9])*\\|)?((?:\\\\.|[A-Za-z_\\-0-9])+)": elementMatch,
 		"\\[([^\\]]+)\\]": attributeMatch,
 		"(\\s*)\\)": nestedEnd,
 		"(\\s*)([>+~])(\\s*)": operatorMatch,

--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -2,6 +2,13 @@
 
 var stringify;
 
+function escape(str) {
+	if(str === "*") {
+		return "*";
+	}
+	return str.replace(/(^[^A-Za-z_\\-]|[^A-Za-z_0-9\\-])/g, "\\$1");
+}
+
 function stringifyWithoutBeforeAfter(tree) {
 	switch(tree.type) {
 	case "selectors":
@@ -9,23 +16,23 @@ function stringifyWithoutBeforeAfter(tree) {
 	case "selector":
 		return tree.nodes.map(stringify).join("");
 	case "element":
-		return (typeof tree.namespace === "string" ? tree.namespace + "|" : "") + tree.name;
+		return (typeof tree.namespace === "string" ? escape(tree.namespace) + "|" : "") + escape(tree.name);
 	case "class":
-		return "." + tree.name;
+		return "." + escape(tree.name);
 	case "id":
-		return "#" + tree.name;
+		return "#" + escape(tree.name);
 	case "attribute":
 		return "[" + tree.content + "]";
 	case "spacing":
 		return tree.value;
 	case "pseudo-class":
-		return ":" + tree.name + (typeof tree.content === "string" ? "(" + tree.content + ")" : "");
+		return ":" + escape(tree.name) + (typeof tree.content === "string" ? "(" + tree.content + ")" : "");
 	case "nested-pseudo-class":
-		return ":" + tree.name + "(" + tree.nodes.map(stringify).join(",") + ")";
+		return ":" + escape(tree.name) + "(" + tree.nodes.map(stringify).join(",") + ")";
 	case "pseudo-element":
-		return "::" + tree.name;
+		return "::" + escape(tree.name);
 	case "universal":
-		return (typeof tree.namespace === "string" ? tree.namespace + "|" : "") + "*";
+		return (typeof tree.namespace === "string" ? escape(tree.namespace) + "|" : "") + "*";
 	case "operator":
 		return tree.operator;
 	case "comment":

--- a/test/test-cases.js
+++ b/test/test-cases.js
@@ -48,6 +48,20 @@ module.exports = {
 		])
 	],
 
+	"complex class name": [
+		".class\\.Name",
+		singleSelector([
+			{ type: "class", name: "class\\.Name" }
+		])
+	],
+
+	"class name starting with number": [
+		".\\5-5",
+		singleSelector([
+			{ type: "class", name: "\\5-5" }
+		])
+	],
+
 	"id name": [
 		"#idName",
 		singleSelector([

--- a/test/test-cases.js
+++ b/test/test-cases.js
@@ -51,14 +51,14 @@ module.exports = {
 	"complex class name": [
 		".class\\.Name",
 		singleSelector([
-			{ type: "class", name: "class\\.Name" }
+			{ type: "class", name: "class.Name" }
 		])
 	],
 
 	"class name starting with number": [
-		".\\5-5",
+		".\\5\\#-\\.5",
 		singleSelector([
-			{ type: "class", name: "\\5-5" }
+			{ type: "class", name: "5#-.5" }
 		])
 	],
 
@@ -69,6 +69,13 @@ module.exports = {
 		])
 	],
 
+	"id name starting with number": [
+		"#\\5\\#-\\.5",
+		singleSelector([
+			{ type: "id", name: "5#-.5" }
+		])
+	],
+
 	"pseudo class": [
 		":before",
 		singleSelector([
@@ -76,10 +83,24 @@ module.exports = {
 		])
 	],
 
+	"pseudo class with escaping": [
+		":be\\:fo\\#r\\.e",
+		singleSelector([
+			{ type: "pseudo-class", name: "be:fo#r.e" }
+		])
+	],
+
 	"pseudo class with content": [
 		":abc(.className)",
 		singleSelector([
 			{ type: "pseudo-class", name: "abc", content: ".className" }
+		])
+	],
+
+	"pseudo class with content and escaping": [
+		":a\\:b\\.c(.className)",
+		singleSelector([
+			{ type: "pseudo-class", name: "a:b.c", content: ".className" }
 		])
 	],
 
@@ -104,6 +125,13 @@ module.exports = {
 		])
 	],
 
+	"pseudo element with escaping": [
+		"::fir\\:\\:st\\.li\\#ne",
+		singleSelector([
+			{ type: "pseudo-element", name: "fir::st.li#ne" }
+		])
+	],
+
 	"universal": [
 		"*",
 		singleSelector([
@@ -115,6 +143,13 @@ module.exports = {
 		"foo|*",
 		singleSelector([
 			{ type: "universal", namespace: "foo" }
+		])
+	],
+
+	"universal with namespace and escaping": [
+		"f\\|o\\.o|*",
+		singleSelector([
+			{ type: "universal", namespace: "f|o.o" }
 		])
 	],
 


### PR DESCRIPTION
Had a quick look at trying to fix this, but wasn't sure the best way. Basically, `.some\.thing {}` is valid CSS and matches up with the HTML `<div class="some.thing">`. Classes can also be started with a number or special character using `\` as well, e.g. `.\1-2 {}`. Added a failing test for each use case.

Thanks!