### PR TITLE
Support 2 digit hex character codes

### DIFF
--- a/lib/parseValues.js
+++ b/lib/parseValues.js
@@ -23,7 +23,7 @@ function endSpacingMatch(match) {
 }
 
 function unescapeString(content) {
-	return content.replace(/\\([a-fA-F0-9]{4}|.)/g, function(escaped) {
+	return content.replace(/\\([a-fA-F0-9]{4}|[a-fA-F0-9]{2}|.)/g, function(escaped) {
 		if(escaped.length > 2) {
 			return String.fromCharCode(parseInt(escaped.substr(1), 16));
 		} else {

--- a/test/test-cases-values.js
+++ b/test/test-cases-values.js
@@ -136,6 +136,12 @@ module.exports = {
 			{ type: "string", stringType: "\"", value: "\uf0e3\\'\"" }
 		])
 	],
+	"escaped unicode 3": [
+		"\"\\2a\\\\'\\\"\"",
+		singleValue([
+			{ type: "string", stringType: "\"", value: "\u002a\\'\"" }
+		])
+	],
 	"nested-item-with append": [
 		"linear-gradient(45deg) 25%",
 		singleValue([


### PR DESCRIPTION
It's legal to have ascii characters represented by a two digit hex code. 

A real world example is here: https://github.com/twbs/bootstrap/blob/master/less/glyphicons.less#L35

This supports them in the `parseValues` function, but the test only half works. Since it's a valid ascii character, it doesn't match when stringified. The stringified value is just the ascii "*".

Advice on how to adapt the test would be great.