### PR TITLE
Fix for stringifying Windows paths

### DIFF
--- a/lib/stringifyValues.js
+++ b/lib/stringifyValues.js
@@ -38,11 +38,11 @@ function stringifyWithoutBeforeAfter(tree) {
 		var end = (tree.innerSpacingAfter || "") + ")";
 		switch(tree.stringType) {
 		case "'":
-			return start + "'" + tree.url.replace(/'/g, "\\'") + "'" + end;
+			return start + "'" + tree.url.replace(/(\\)/g, "\\$1").replace(/'/g, "\\'") + "'" + end;
 		case "\"":
-			return start + "\"" + tree.url.replace(/"/g, "\\\"") + "\"" + end;
+			return start + "\"" + tree.url.replace(/(\\)/g, "\\$1").replace(/"/g, "\\\"") + "\"" + end;
 		default:
-			return start + tree.url.replace(/("|'|\))/g, "\\$1") + end;
+			return start + tree.url.replace(/("|'|\)|\\)/g, "\\$1") + end;
 		}
 	}
 }

--- a/test/test-cases-values.js
+++ b/test/test-cases-values.js
@@ -68,6 +68,12 @@ module.exports = {
 			{ type: "url", url: "ghi)j\"k", innerSpacingBefore: " " }
 		])
 	],
+	"windows-urls": [
+		"url('C:\\\\Users\\\\Test\\\\test.png')",
+		singleValue([
+			{ type: "url", url: "C:\\Users\\Test\\test.png", stringType: "'"}
+		])
+	],
 	"nested-item": [
 		"format('woff')",
 		singleValue([


### PR DESCRIPTION
Currently stringifyValues and parseValues are not reversible for urls containing Windows-style paths, or just containing backslashes.  If you generate a url string with stringifyValues and then parse the same with parseValues, all the slashes are decoded.