### PR TITLE
fixed unescapeString parseValues.js

### DIFF
--- a/lib/parseValues.js
+++ b/lib/parseValues.js
@@ -23,11 +23,7 @@ function endSpacingMatch(match) {
 }
 
 function unescapeString(content) {
-	return content.replace(/\\(?:([a-fA-F0-9]{1,6})|(.))/g, function(all, unicode, otherCharacter) {
-		if (otherCharacter) {
-			return otherCharacter;
-		}
-
+	function conv(all, unicode) {
 		var C = parseInt(unicode, 16);
 		if(C < 0x10000) {
 			return String.fromCharCode(C);
@@ -35,7 +31,13 @@ function unescapeString(content) {
 			return String.fromCharCode(Math.floor((C - 0x10000) / 0x400) + 0xD800) +
 				String.fromCharCode((C - 0x10000) % 0x400 + 0xDC00);
 		}
-	});
+	}
+
+	return content
+		.replace(/\\([a-fA-F0-9]{1,6}) /g, conv)
+		.replace(/\\([a-fA-F0-9]{6})/g, conv)
+		.replace(/\\([a-fA-F0-9]{1,5})(?![a-fA-F0-9])/g, conv)
+	;
 }
 
 function stringMatch(match, content) {


### PR DESCRIPTION
fixed unescapeString in the same manner as google chrome.

Trailing space is unicode terminator, to be deleted.
'hei\DF en' -> 'heißen'
'hei\00DF en' -> 'heißen'
'hei\0000DF en' -> 'heißen'

Six characters of the unicode without terminator.
'hei\0000DFen' -> 'heißen'

Non hex-character is unicode terminator, to be passed.
'hei\DFt' -> 'heißt'
