### PR TITLE
chore(deps): upgrade to latest stable

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,0 @@
-{
-	"env": {
-		"node": true
-	},
-	"rules": {
-	}
-}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,12 @@
+{
+    "env": {
+        "browser": true,
+        "commonjs": true,
+        "es6": true,
+        "node": true
+    },
+    "extends": "eslint:recommended",
+    "parserOptions": {
+        "ecmaVersion": 2018
+    }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 coverage
+.nyc_output
+package-lock.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,13 @@
-sudo: false
 language: node_js
-node_js:
-  - "0.10"
-  - "0.12"
-  - "iojs"
-script: npm run travis
 
-before_install:
-  - '[ "${TRAVIS_NODE_VERSION}" != "0.10" ] || npm install -g npm'
+node_js:
+  - 10
+  - 12
+  - 13
+
+script: npm run cover
 
 after_success:
-  - cat ./coverage/lcov.info | node_modules/.bin/coveralls --verbose
-  - cat ./coverage/coverage.json | node_modules/codecov.io/bin/codecov.io.js
-  - rm -rf ./coverage
+  - npm run report:coveralls
+  - npm run report:codecov
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# CSS Modules: CSS selector Tokenizer
+# CSS Modules: css-selector-tokenizer
+[![Build Status](https://travis-ci.org/css-modules/css-selector-tokenizer.svg?branch=master)](https://travis-ci.org/css-modules/css-selector-tokenizer)
+[![coveralls.io](https://coveralls.io/repos/css-modules/css-selector-tokenizer/badge.svg?branch=master)](https://coveralls.io/r/css-modules/css-selector-tokenizer?branch=master)
+[![codecov.io](https://codecov.io/github/css-modules/css-selector-tokenizer/coverage.svg?branch=master)](https://codecov.io/github/css-modules/css-selector-tokenizer?branch=master)
 
 Parses and stringifies CSS selectors.
 
@@ -71,14 +74,9 @@ npm install
 npm test
 ```
 
-[![Build Status](https://travis-ci.org/css-modules/css-selector-tokenizer.svg?branch=master)](https://travis-ci.org/css-modules/css-selector-tokenizer)
-
-* Lines: [![Coverage Status](https://coveralls.io/repos/css-modules/css-selector-tokenizer/badge.svg?branch=master)](https://coveralls.io/r/css-modules/css-selector-tokenizer?branch=master)
-* Statements: [![codecov.io](http://codecov.io/github/css-modules/css-selector-tokenizer/coverage.svg?branch=master)](http://codecov.io/github/css-modules/css-selector-tokenizer?branch=master)
-
 ## Development
 
-- `npm autotest` will watch `lib` and `test` for changes and retest
+- `npm test -- -w` will watch `lib` and `test` for changes and retest
 
 ## License
 

--- a/lib/parseValues.js
+++ b/lib/parseValues.js
@@ -136,12 +136,12 @@ var parser = new Parser({
 		"url\\((\\s*)(\"(?:[^\\\\\"]|\\\\.)*\")(\\s*)\\)": urlMatch,
 		"url\\((\\s*)('(?:[^\\\\']|\\\\.)*')(\\s*)\\)": urlMatch,
 		"url\\((\\s*)((?:[^\\\\)'\"]|\\\\.)*)(\\s*)\\)": urlMatch,
-		"([\\w\-]+)\\((\\s*)": nestedItemMatch,
+		"([\\w-]+)\\((\\s*)": nestedItemMatch,
 		"(\\s*)(\\))": nestedItemEndMatch,
 		",(\\s*)": commaMatch,
 		"\\s+$": endSpacingMatch,
 		"\\s+": spacingMatch,
-		"[^\\s,\)]+": itemMatch
+		"[^\\s,)]+": itemMatch
 	}
 });
 

--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -13,7 +13,7 @@ function escape(str, identifier) {
 	if (identifier) {
 		return str.replace(identifierEscapeRegexp, "\\$1");
 	} else {
-		return str.replace(/(^[^A-Za-z_\\-]|^\-\-|[^A-Za-z_0-9\\-])/g, "\\$1");
+		return str.replace(/(^[^A-Za-z_\\-]|^--|[^A-Za-z_0-9\\-])/g, "\\$1");
 	}
 }
 
@@ -60,6 +60,6 @@ function stringify(tree) {
 		str = str + tree.after;
 	}
 	return str;
-};
+}
 
 module.exports = stringify;

--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -1,10 +1,8 @@
 "use strict";
 
-var stringify;
-
 var regexpu = require("regexpu-core");
 var identifierEscapeRegexp = new RegExp(
-	regexpu("(^[^A-Za-z_\\-\\u{00a0}-\\u{10ffff}]|^\\-\\-|[^A-Za-z_0-9\\-\\u{00a0}-\\u{10ffff}])", "ug"),
+	regexpu("(^[^A-Za-z_\\-\\u{00a0}-\\u{10ffff}]|^--|[^A-Za-z_0-9\\-\\u{00a0}-\\u{10ffff}])", "ug"),
 	"g"
 );
 
@@ -53,7 +51,7 @@ function stringifyWithoutBeforeAfter(tree) {
 }
 
 
-stringify = function stringify(tree) {
+function stringify(tree) {
 	var str = stringifyWithoutBeforeAfter(tree);
 	if(tree.before) {
 		str = tree.before + str;

--- a/package.json
+++ b/package.json
@@ -4,13 +4,12 @@
   "description": "Parses and stringifies CSS selectors",
   "main": "lib/index.js",
   "scripts": {
-    "lint": "eslint lib",
+    "lint": "eslint .",
     "pretest": "npm run lint",
     "test": "mocha",
-    "autotest": "chokidar lib test -c 'npm test'",
-    "precover": "npm run lint",
-    "cover": "istanbul cover node_modules/mocha/bin/_mocha",
-    "travis": "npm run cover -- --report lcovonly",
+    "cover": "nyc npm test",
+    "report:coveralls": "nyc report --reporter=text-lcov | coveralls",
+    "report:codecov": "nyc report --reporter=text-lcov | codecov --pipe",
     "publish-patch": "npm test && npm version patch && git push && git push --tags && npm publish"
   },
   "repository": {
@@ -31,17 +30,16 @@
   },
   "homepage": "https://github.com/css-modules/css-selector-tokenizer",
   "dependencies": {
-    "cssesc": "^0.1.0",
-    "fastparse": "^1.1.1",
-    "regexpu-core": "^1.0.0"
+    "cssesc": "^3.0.0",
+    "fastparse": "^1.1.2",
+    "regexpu-core": "^4.6.0"
   },
   "devDependencies": {
-    "chokidar-cli": "^0.2.1",
-    "codecov.io": "^0.1.2",
-    "coveralls": "^2.11.2",
-    "eslint": "^0.21.2",
-    "istanbul": "^0.3.14",
-    "mocha": "^2.2.5"
+    "codecov": "^3.6.5",
+    "coveralls": "^3.0.9",
+    "eslint": "^6.8.0",
+    "mocha": "^7.0.1",
+    "nyc": "^15.0.0"
   },
   "directories": {
     "test": "test"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "codecov": "^3.6.5",
     "coveralls": "^3.0.9",
     "eslint": "^6.8.0",
-    "mocha": "^7.0.1",
+    "mocha": "^7.1.0",
     "nyc": "^15.0.0"
   },
   "directories": {


### PR DESCRIPTION
- cleaned up `travis.yml`. it now runs node 10/12/13.
- cleaner coverage report scripts for each service.
- replaced deprecated `instanbul` with `nyc`.
- removed `autotest` script. mocha has its own watcher (`npm test -- -w`)