### PR TITLE
Support new :is and :where parsing

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -178,7 +178,7 @@ function getSelectors() {
 	selectors[uniRegexp.typeMatchClass] = typeMatch("class");
 	selectors[uniRegexp.typeMatchId] = typeMatch("id");
 	var selectorsSecondHalf = {
-		":(not|matches|is|where|has|local|global)\\((\\s*)": nestedPseudoClassStartMatch,
+		":(not|any|-\\w+?-any|matches|is|where|has|local|global)\\((\\s*)": nestedPseudoClassStartMatch,
 		":((?:\\\\.|[A-Za-z_\\-0-9])+)\\(": pseudoClassStartMatch,
 		":((?:\\\\.|[A-Za-z_\\-0-9])+)": typeMatch("pseudo-class"),
 		"::((?:\\\\.|[A-Za-z_\\-0-9])+)": typeMatch("pseudo-element"),

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -178,7 +178,7 @@ function getSelectors() {
 	selectors[uniRegexp.typeMatchClass] = typeMatch("class");
 	selectors[uniRegexp.typeMatchId] = typeMatch("id");
 	var selectorsSecondHalf = {
-		":(not|matches|has|local|global)\\((\\s*)": nestedPseudoClassStartMatch,
+		":(not|matches|is|where|has|local|global)\\((\\s*)": nestedPseudoClassStartMatch,
 		":((?:\\\\.|[A-Za-z_\\-0-9])+)\\(": pseudoClassStartMatch,
 		":((?:\\\\.|[A-Za-z_\\-0-9])+)": typeMatch("pseudo-class"),
 		"::((?:\\\\.|[A-Za-z_\\-0-9])+)": typeMatch("pseudo-element"),

--- a/test/test-cases.js
+++ b/test/test-cases.js
@@ -411,6 +411,56 @@ module.exports = {
 			],
 		}, ]),
 	],
+	"nested pseudo class with multiple selectors (:any)": [
+		":any( h1, h2 )",
+		singleSelector([{
+			type: "nested-pseudo-class",
+			name: "any",
+			nodes: [{
+					type: "selector",
+					nodes: [{
+						type: "element",
+						name: "h1"
+					}],
+					before: " ",
+				},
+				{
+					type: "selector",
+					nodes: [{
+						type: "element",
+						name: "h2"
+					}],
+					before: " ",
+					after: " ",
+				},
+			],
+		}, ]),
+	],
+	"nested pseudo class with multiple selectors (:-vendor-any)": [
+		":-vendor-any( h1, h2 )",
+		singleSelector([{
+			type: "nested-pseudo-class",
+			name: "-vendor-any",
+			nodes: [{
+					type: "selector",
+					nodes: [{
+						type: "element",
+						name: "h1"
+					}],
+					before: " ",
+				},
+				{
+					type: "selector",
+					nodes: [{
+						type: "element",
+						name: "h2"
+					}],
+					before: " ",
+					after: " ",
+				},
+			],
+		}, ]),
+	],
 	"available nested pseudo classes": [
 		":not(:active):matches(:focus)",
 		singleSelector([

--- a/test/test-cases.js
+++ b/test/test-cases.js
@@ -361,50 +361,56 @@ module.exports = {
 			] }
 		])
 	],
-  "nested pseudo class with multiple selectors (:is)": [
-    ":is( h1, h2 )",
-    singleSelector([
-    {
-        type: "nested-pseudo-class",
-        name: "is",
-        nodes: [
-        {
-            type: "selector",
-            nodes: [{ type: "element", name: "h1" }],
-            before: " ",
-        },
-        {
-            type: "selector",
-            nodes: [{ type: "element", name: "h2" }],
-            before: " ",
-            after: " ",
-        },
-        ],
-    },
-    ]),
-  ],
-  "nested pseudo class with multiple selectors (:where)": [
-      ":where( h1, h2 )",
-      singleSelector([
-      {
-          type: "nested-pseudo-class",
-          name: "where",
-          nodes: [
-          {
-              type: "selector",
-              nodes: [{ type: "element", name: "h1" }],
-              before: " ",
-          },
-          {
-              type: "selector",
-              nodes: [{ type: "element", name: "h2" }],
-              before: " ",
-              after: " ",
-          },
-          ],
-      },
-      ]),
-  ],
+	"nested pseudo class with multiple selectors (:is)": [
+		":is( h1, h2 )",
+		singleSelector([{
+			type: "nested-pseudo-class",
+			name: "is",
+			nodes: [{
+					type: "selector",
+					nodes: [{
+						type: "element",
+						name: "h1"
+					}],
+					before: " ",
+				},
+				{
+					type: "selector",
+					nodes: [{
+						type: "element",
+						name: "h2"
+					}],
+					before: " ",
+					after: " ",
+				},
+			],
+		}, ]),
+	],
+	"nested pseudo class with multiple selectors (:where)": [
+		":where( h1, h2 )",
+		singleSelector([{
+			type: "nested-pseudo-class",
+			name: "where",
+			nodes: [{
+					type: "selector",
+					nodes: [{
+						type: "element",
+						name: "h1"
+					}],
+					before: " ",
+				},
+				{
+					type: "selector",
+					nodes: [{
+						type: "element",
+						name: "h2"
+					}],
+					before: " ",
+					after: " ",
+				},
+			],
+		}, ]),
+	],
 	"available nested pseudo classes": [
 		":not(:active):matches(:focus)",
 		singleSelector([

--- a/test/test-cases.js
+++ b/test/test-cases.js
@@ -361,7 +361,50 @@ module.exports = {
 			] }
 		])
 	],
-
+  "nested pseudo class with multiple selectors (:is)": [
+    ":is( h1, h2 )",
+    singleSelector([
+    {
+        type: "nested-pseudo-class",
+        name: "is",
+        nodes: [
+        {
+            type: "selector",
+            nodes: [{ type: "element", name: "h1" }],
+            before: " ",
+        },
+        {
+            type: "selector",
+            nodes: [{ type: "element", name: "h2" }],
+            before: " ",
+            after: " ",
+        },
+        ],
+    },
+    ]),
+  ],
+  "nested pseudo class with multiple selectors (:where)": [
+      ":where( h1, h2 )",
+      singleSelector([
+      {
+          type: "nested-pseudo-class",
+          name: "where",
+          nodes: [
+          {
+              type: "selector",
+              nodes: [{ type: "element", name: "h1" }],
+              before: " ",
+          },
+          {
+              type: "selector",
+              nodes: [{ type: "element", name: "h2" }],
+              before: " ",
+              after: " ",
+          },
+          ],
+      },
+      ]),
+  ],
 	"available nested pseudo classes": [
 		":not(:active):matches(:focus)",
 		singleSelector([


### PR DESCRIPTION
Add support for parsing `:is` and `:where` as nested-pseudo-classes